### PR TITLE
Allow switches to get linked

### DIFF
--- a/src/components/switches/switch.cpp
+++ b/src/components/switches/switch.cpp
@@ -66,6 +66,17 @@ void Switch::stamp()
     onbuttonclicked();
 }
 
+void Switch::setLinkedValue( double v, int i )
+{
+    int vInt = v;
+    bool checked = Switch::checked();
+
+    bool new_state = vInt == 0;
+    if (checked != new_state) {
+        Switch::setChecked(new_state);
+    }
+}
+
 void Switch::keyEvent( QString key, bool pressed )
 {
     if( key == m_key )

--- a/src/components/switches/switch.h
+++ b/src/components/switches/switch.h
@@ -22,6 +22,7 @@ class Switch : public SwitchBase
 
         bool checked();
         void setChecked( bool c );
+        void setLinkedValue( double v, int i ) override;
 
         void paint( QPainter* p, const QStyleOptionGraphicsItem* o, QWidget* w ) override;
 


### PR DESCRIPTION
It uses a new field "Link condition" to evaluate which value triggers the switch

Tracking values reported by dc motor I get updates in 44 steps so a fixed value do not work

When value to match is near 1000 or 0 you need to consider this condition:

    (>=900 and <=1000) or (>=0 and <=100)

Example to simulate a limit switch:

[h-bridge-dev.zip](https://github.com/user-attachments/files/24312664/h-bridge-dev.zip)

fixes #78 